### PR TITLE
Fix eager loading for chapter reciters

### DIFF
--- a/app/presenters/audio/recitation_presenter.rb
+++ b/app/presenters/audio/recitation_presenter.rb
@@ -9,8 +9,8 @@ class Audio::RecitationPresenter < BasePresenter
 
   def recitations
     relation = Audio::Recitation
-                 .includes(:recitation_style, :qirat_type, reciter: :translated_name)
-                 .eager_load(reciter: :translated_name)
+                 .includes(:translated_name, :recitation_style, :qirat_type, reciter: :translated_name)
+                 .eager_load(:translated_name, reciter: :translated_name)
                  .order('priority ASC, language_priority DESC')
 
     eager_load_translated_name filter_recitations(relation)

--- a/spec/apis/v4/chapter_reciters_spec.rb
+++ b/spec/apis/v4/chapter_reciters_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+
+describe 'Chapter reciters endpoint', type: :api do
+  context 'when no recitations exist' do
+    it 'returns an empty list' do
+      get '/api/v4/resources/chapter_reciters', chapter_id: 1
+      expect(last_response.status).to eq(200)
+      expect(Oj.load(last_response.body)['reciters']).to eq([])
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- eager load recitations' own translated names
- add regression test for chapter_reciters endpoint

## Testing
- `bundle exec rspec spec/apis/v4/chapter_reciters_spec.rb -fd` *(fails: Could not find cld3-3.4.3)*

------
https://chatgpt.com/codex/tasks/task_e_684111bfa668832b8c62db832dafb9c4