### PR TITLE
fix: make v4 page layout mushaf-aware and add missing v4 pages endpoints

### DIFF
--- a/app/controllers/api/v4/pages_controller.rb
+++ b/app/controllers/api/v4/pages_controller.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Api::V4
+  class PagesController < ApiController
+    before_action :init_presenter
+
+    def index
+      render
+    end
+
+    def show
+      render
+    end
+
+    def lookup
+      render
+    end
+
+    protected
+
+    def init_presenter
+      @presenter = Qdc::MushafPagePresenter.new(params)
+    end
+  end
+end

--- a/app/finders/v4/verse_finder.rb
+++ b/app/finders/v4/verse_finder.rb
@@ -3,6 +3,7 @@
 #TODO: replace with QdcFinder
 class V4::VerseFinder < ::VerseFinder
   def random_verse(filters, language_code, words: true, tafsirs: false, translations: false, audio: false)
+    @mushaf_page_layout = false
     @results = Verse.unscope(:order).where(filters).order('RANDOM()').limit(3)
 
     load_words(language_code) if words
@@ -18,6 +19,7 @@ class V4::VerseFinder < ::VerseFinder
   end
 
   def find_with_key(key, language_code, words: true, tafsirs: false, translations: false, audio: false)
+    @mushaf_page_layout = false
     @results = Verse.where(verse_key: key).limit(1)
 
     load_words(language_code) if words
@@ -33,12 +35,14 @@ class V4::VerseFinder < ::VerseFinder
   end
 
   def load_verses(filter, language_code, mushaf: nil, words: true, tafsirs: false, translations: false, audio: false)
-    fetch_verses_range(filter, mushaf: mushaf)
-    load_words(language_code) if words
+    @mushaf_page_layout = filter == 'by_page'
+
+    fetch_verses_range(filter, mushaf: mushaf, words: words)
+    load_words(language_code, mushaf: mushaf) if words
     load_audio(audio) if audio
     load_tafsirs(tafsirs) if tafsirs.present?
 
-    words_ordering = words ? ', words.position ASC, word_translations.priority ASC' : ''
+    words_ordering = word_ordering_clause(words)
 
     records = @results.order("verses.verse_index ASC #{words_ordering}".strip).to_a
     preload_translations(records, translations) if translations.present?
@@ -48,9 +52,11 @@ class V4::VerseFinder < ::VerseFinder
 
   # TODO: it's time to merge v4 and qdc
   # We are writing lot of duplicate code now
-  def fetch_verses_range(filter, mushaf: nil)
+  def fetch_verses_range(filter, mushaf: nil, words: false)
     if 'by_range' == filter
       @results = fetch_by_range
+    elsif 'by_page' == filter
+      @results = fetch_by_page(mushaf: mushaf, words: words)
     elsif 'by_juz' == filter
       @results = fetch_by_juz(mushaf: mushaf)
     else
@@ -102,13 +108,21 @@ class V4::VerseFinder < ::VerseFinder
                  .where('verses.verse_number >= ? AND verses.verse_number <= ?', verse_start.to_i, verse_end.to_i)
   end
 
-  def fetch_by_page
-    mushaf_page = find_mushaf_page
+  def fetch_by_page(mushaf:, words:)
+    mushaf_page = find_mushaf_page(mushaf: mushaf)
     # Disable pagination for by_page route
     @per_page = @total_records = mushaf_page.verses_count
     @next_page = nil
 
-    @results = rescope_verses('verse_index').where(page_number: mushaf_page.page_number)
+    @results = rescope_verses('verse_index')
+                 .where('verses.verse_index >= ? AND verses.verse_index <= ?', mushaf_page.first_verse_id, mushaf_page.last_verse_id)
+
+    only_page_words = params[:filter_page_words] == 'true'
+    if words && mushaf.lines_per_page == 16 && only_page_words
+      @results = @results.where(mushaf_words: { page_number: mushaf_page.page_number })
+    else
+      @results
+    end
   end
 
   def fetch_by_rub_el_hizb
@@ -248,7 +262,9 @@ class V4::VerseFinder < ::VerseFinder
     end
   end
 
-  def load_words(word_translation_lang)
+  def load_words(word_translation_lang, mushaf: nil)
+    return load_page_words(word_translation_lang, mushaf) if @mushaf_page_layout
+
     language = Language.find_with_id_or_iso_code(word_translation_lang)
 
     approved_word_by_word_translations = ResourceContent.approved.allowed_to_share.one_word.translations_only
@@ -261,6 +277,23 @@ class V4::VerseFinder < ::VerseFinder
                    .eager_load(words: eager_load_words)
     else
       @results = words_with_default_translation.eager_load(words: eager_load_words)
+    end
+  end
+
+  def load_page_words(word_translation_lang, mushaf)
+    language = Language.find_with_id_or_iso_code(word_translation_lang)
+
+    @results = @results.where(mushaf_words: { mushaf_id: mushaf.id })
+    approved_word_by_word_translations = ResourceContent.approved.allowed_to_share.one_word.translations_only
+    words_with_default_translation = @results.where(word_translations: { language_id: Language.default.id })
+
+    if language
+      @results = @results
+                   .where(word_translations: { language_id: language.id, resource_content_id: approved_word_by_word_translations })
+                   .or(words_with_default_translation)
+                   .eager_load(mushaf_words: eager_load_mushaf_words)
+    else
+      @results = words_with_default_translation.eager_load(mushaf_words: eager_load_mushaf_words)
     end
   end
 
@@ -287,5 +320,19 @@ class V4::VerseFinder < ::VerseFinder
 
   def rescope_verses(by)
     Verse.unscope(:order).order("#{by} ASC")
+  end
+
+  def eager_load_mushaf_words
+    [:word_translation, :word]
+  end
+
+  def word_ordering_clause(words)
+    return '' unless words
+
+    if @mushaf_page_layout
+      ', mushaf_words.position_in_verse ASC, word_translations.priority ASC'
+    else
+      ', words.position ASC, word_translations.priority ASC'
+    end
   end
 end

--- a/app/presenters/verses_presenter.rb
+++ b/app/presenters/verses_presenter.rb
@@ -189,6 +189,38 @@ class VersesPresenter < BasePresenter
     end
   end
 
+  def mushaf_page_layout?
+    verses_filter == 'by_page'
+  end
+
+  def verse_page_number_for(verse, page_layout: mushaf_page_layout?)
+    if page_layout
+      verse.get_page_number_for(mushaf: get_mushaf_id)
+    else
+      verse.get_qpc_page_number(get_mushaf_code)
+    end
+  end
+
+  def verse_words_for(verse, page_layout: mushaf_page_layout?)
+    if page_layout
+      verse.mushaf_words.sort_by(&:position_in_verse)
+    else
+      verse.words
+    end
+  end
+
+  def word_partial_locals(page_layout: mushaf_page_layout?)
+    locals = { fields: word_fields }
+
+    if page_layout
+      locals[:page_layout] = true
+    else
+      locals[:mushaf_code] = get_mushaf_code
+    end
+
+    locals
+  end
+
   def fetch_chapters
     chapters = Chapter.where(id: chapter_ids).includes(:translated_name)
 

--- a/app/views/api/v4/pages/_page.json.streamer
+++ b/app/views/api/v4/pages/_page.json.streamer
@@ -1,0 +1,1 @@
+json.partial! 'api/qdc/pages/page', page: page

--- a/app/views/api/v4/pages/index.json.streamer
+++ b/app/views/api/v4/pages/index.json.streamer
@@ -1,0 +1,7 @@
+json.object! do
+  json.pages do
+    json.array! @presenter.pages do |page|
+      json.partial! 'page', page: page
+    end
+  end
+end

--- a/app/views/api/v4/pages/lookup.json.streamer
+++ b/app/views/api/v4/pages/lookup.json.streamer
@@ -1,0 +1,24 @@
+pages = @presenter.lookup
+lookup_range_keys = @presenter.lookup_range_keys
+
+json.object! do
+  json.total_page pages.size
+  json.lookup_range lookup_range_keys
+
+  json.pages do
+    json.object! do
+      pages.each do |page|
+        filtered_range = @presenter.filtered_lookup_range_for_page(page)
+
+        json.set! page.page_number do
+          json.object! do
+            json.first_verse_key page.first_verse_key
+            json.last_verse_key page.last_verse_key
+            json.from filtered_range[:from]
+            json.to filtered_range[:to]
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/views/api/v4/pages/show.json.streamer
+++ b/app/views/api/v4/pages/show.json.streamer
@@ -1,0 +1,5 @@
+json.object! do
+  json.page do
+    json.partial! 'page', page: @presenter.page
+  end
+end

--- a/app/views/api/v4/verses/_verse.json.streamer
+++ b/app/views/api/v4/verses/_verse.json.streamer
@@ -5,11 +5,10 @@ include_translations = @presenter.render_translations?
 include_audio = @presenter.render_audio?
 include_tafsirs = @presenter.render_tafsirs?
 fields = @presenter.verse_fields
-word_fields = @presenter.word_fields
 tafsir_fields = @presenter.tafsir_fields
 translation_fields = @presenter.translation_fields
-mushaf_code = @presenter.get_mushaf_code
 mushaf_type = @presenter.get_mushaf_type
+page_layout = @presenter.mushaf_page_layout?
 
 json.object! do
   json.verse do
@@ -23,12 +22,15 @@ json.object! do
                     :manzil_number,
                     :sajdah_number, *fields
 
-      json.page_number verse.get_qpc_page_number(mushaf_code)
+      json.page_number @presenter.verse_page_number_for(verse, page_layout: page_layout)
       json.juz_number verse.get_juz_number_for(mushaf_type: mushaf_type)
 
       if include_words
         json.words do
-          json.array! verse.words, partial: 'word', as: :word, locals: { fields: word_fields, mushaf_code: mushaf_code }
+          json.array! @presenter.verse_words_for(verse, page_layout: page_layout),
+                      partial: 'word',
+                      as: :word,
+                      locals: @presenter.word_partial_locals(page_layout: page_layout)
         end
       end
 

--- a/app/views/api/v4/verses/_verses.json.streamer
+++ b/app/views/api/v4/verses/_verses.json.streamer
@@ -5,11 +5,10 @@ include_translations = @presenter.render_translations?
 include_audio = @presenter.render_audio?
 include_tafsirs = @presenter.render_tafsirs?
 fields = @presenter.verse_fields
-word_fields = @presenter.word_fields
 tafsir_fields = @presenter.tafsir_fields
 translation_fields = @presenter.translation_fields
-mushaf_code = @presenter.get_mushaf_code
 mushaf_type = @presenter.get_mushaf_type
+page_layout = @presenter.mushaf_page_layout?
 
 json.object! do
   json.verses do
@@ -24,12 +23,15 @@ json.object! do
                       :manzil_number,
                       :sajdah_number, *fields
 
-        json.page_number verse.get_qpc_page_number(mushaf_code)
+        json.page_number @presenter.verse_page_number_for(verse, page_layout: page_layout)
         json.juz_number verse.get_juz_number_for(mushaf_type: mushaf_type)
 
         if include_words
           json.words do
-            json.array! verse.words, partial: 'word', as: :word, locals: { fields: word_fields, mushaf_code: mushaf_code }
+            json.array! @presenter.verse_words_for(verse, page_layout: page_layout),
+                        partial: 'word',
+                        as: :word,
+                        locals: @presenter.word_partial_locals(page_layout: page_layout)
           end
         end
 

--- a/app/views/api/v4/verses/_word.json.streamer
+++ b/app/views/api/v4/verses/_word.json.streamer
@@ -1,16 +1,25 @@
 # frozen_string_literal: true
 
+page_layout = local_assigns.fetch(:page_layout, word.respond_to?(:word_id))
+mushaf_code = local_assigns[:mushaf_code] || :v1
+
 json.object! do
+  json.id(page_layout ? word.word_id : word.id)
   json.extract! word,
-                :id,
                 :position,
                 :audio_url,
                 :char_type_name,
                 *fields
 
-  json.page_number word.get_qpc_page_number(mushaf_code)
-  json.line_number word.get_qpc_line_number(mushaf_code)
-  json.text word.get_text(mushaf_code)
+  if page_layout
+    json.page_number word.page_number
+    json.line_number word.line_number
+    json.text word.text
+  else
+    json.page_number word.get_qpc_page_number(mushaf_code)
+    json.line_number word.get_qpc_line_number(mushaf_code)
+    json.text word.get_text(mushaf_code)
+  end
 
   json.translation do
     json.object! do

--- a/app/views/api/v4/verses/random.json.streamer
+++ b/app/views/api/v4/verses/random.json.streamer
@@ -27,12 +27,15 @@ json.object! do
                     :manzil_number,
                     :sajdah_number, *fields
 
-      json.page_number verse.get_page_number_for(mushaf: mushaf_id)
+      json.page_number @presenter.verse_page_number_for(verse, page_layout: true)
       json.juz_number verse.get_juz_number_for(mushaf_type: mushaf_type)
 
       if include_words
         json.words do
-          json.array! verse.mushaf_words.order('position_in_verse ASC'), partial: 'word', as: :word, locals: { fields: word_fields }
+          json.array! @presenter.verse_words_for(verse, page_layout: true),
+                      partial: 'word',
+                      as: :word,
+                      locals: @presenter.word_partial_locals(page_layout: true)
         end
       end
 

--- a/config/routes/api/v4.rb
+++ b/config/routes/api/v4.rb
@@ -38,6 +38,11 @@ namespace :v4 do
   get :chapters, to: 'chapters#index'
   get 'chapters/:id', to: 'chapters#show'
 
+  # Page
+  get 'pages', to: 'pages#index'
+  get 'pages/lookup', to: 'pages#lookup'
+  get 'pages/:id', to: 'pages#show'
+
   # Chapter info
   get 'chapters/:id/info', to: 'chapter_infos#show'
 

--- a/oas.json
+++ b/oas.json
@@ -159,7 +159,8 @@
                             "properties": {
                                 "chapters": {
                                     "type": "array",
-                                    "items": {}
+                                    "items": {
+                                    }
                                 }
                             }
                         },
@@ -248,6 +249,283 @@
                                         "language_name": "english",
                                         "name": "The Opener"
                                     }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/pages": {
+            "get": {
+                "operationId": "LIST-pages",
+                "summary": "List Pages",
+                "tags": [
+                    "Pages"
+                ],
+                "description": "Get all pages for the selected mushaf.",
+                "parameters": [
+                    {
+                        "name": "mushaf",
+                        "in": "query",
+                        "description": "Optional mushaf id. Defaults to the system default mushaf.",
+                        "type": "integer"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "pages": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "object",
+                                        "properties": {
+                                            "id": {
+                                                "type": "integer"
+                                            },
+                                            "page_number": {
+                                                "type": "integer"
+                                            },
+                                            "verse_mapping": {
+                                                "type": "object"
+                                            },
+                                            "first_verse_id": {
+                                                "type": "integer"
+                                            },
+                                            "last_verse_id": {
+                                                "type": "integer"
+                                            },
+                                            "verses_count": {
+                                                "type": "integer"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "examples": {
+                            "application/json": {
+                                "pages": [
+                                    {
+                                        "id": 1,
+                                        "page_number": 507,
+                                        "verse_mapping": {
+                                            "47:1": "47:3"
+                                        },
+                                        "first_verse_id": 4787,
+                                        "last_verse_id": 4789,
+                                        "verses_count": 3
+                                    }
+                                ]
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/pages/lookup": {
+            "get": {
+                "operationId": "GET-pages-lookup",
+                "summary": "Lookup Pages",
+                "tags": [
+                    "Pages"
+                ],
+                "description": "Get page boundaries for a chapter, juz, page, or verse range in the selected mushaf.",
+                "parameters": [
+                    {
+                        "name": "mushaf",
+                        "in": "query",
+                        "description": "Optional mushaf id. Defaults to the system default mushaf.",
+                        "type": "integer"
+                    },
+                    {
+                        "name": "chapter_number",
+                        "in": "query",
+                        "type": "integer"
+                    },
+                    {
+                        "name": "juz_number",
+                        "in": "query",
+                        "type": "integer"
+                    },
+                    {
+                        "name": "page_number",
+                        "in": "query",
+                        "type": "integer"
+                    },
+                    {
+                        "name": "manzil_number",
+                        "in": "query",
+                        "type": "integer"
+                    },
+                    {
+                        "name": "rub_el_hizb_number",
+                        "in": "query",
+                        "type": "integer"
+                    },
+                    {
+                        "name": "hizb_number",
+                        "in": "query",
+                        "type": "integer"
+                    },
+                    {
+                        "name": "ruku_number",
+                        "in": "query",
+                        "type": "integer"
+                    },
+                    {
+                        "name": "from",
+                        "in": "query",
+                        "description": "Starting verse key or verse id.",
+                        "type": "string"
+                    },
+                    {
+                        "name": "to",
+                        "in": "query",
+                        "description": "Ending verse key or verse id.",
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "total_page": {
+                                    "type": "integer"
+                                },
+                                "lookup_range": {
+                                    "type": "object",
+                                    "properties": {
+                                        "from": {
+                                            "type": "string"
+                                        },
+                                        "to": {
+                                            "type": "string"
+                                        }
+                                    }
+                                },
+                                "pages": {
+                                    "type": "object",
+                                    "additionalProperties": {
+                                        "type": "object",
+                                        "properties": {
+                                            "first_verse_key": {
+                                                "type": "string"
+                                            },
+                                            "last_verse_key": {
+                                                "type": "string"
+                                            },
+                                            "from": {
+                                                "type": "string"
+                                            },
+                                            "to": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "examples": {
+                            "application/json": {
+                                "total_page": 2,
+                                "lookup_range": {
+                                    "from": "47:1",
+                                    "to": "47:5"
+                                },
+                                "pages": {
+                                    "507": {
+                                        "first_verse_key": "47:1",
+                                        "last_verse_key": "47:3",
+                                        "from": "47:1",
+                                        "to": "47:3"
+                                    },
+                                    "508": {
+                                        "first_verse_key": "47:4",
+                                        "last_verse_key": "47:5",
+                                        "from": "47:4",
+                                        "to": "47:5"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/pages/{id}": {
+            "parameters": [
+                {
+                    "name": "id",
+                    "in": "path",
+                    "description": "Page number in the selected mushaf.",
+                    "required": true,
+                    "type": "integer",
+                    "minimum": 1
+                }
+            ],
+            "get": {
+                "operationId": "GET-pages-page_number",
+                "summary": "Get Page",
+                "tags": [
+                    "Pages"
+                ],
+                "description": "Get metadata for a single page in the selected mushaf.",
+                "parameters": [
+                    {
+                        "name": "mushaf",
+                        "in": "query",
+                        "description": "Optional mushaf id. Defaults to the system default mushaf.",
+                        "type": "integer"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "page": {
+                                    "type": "object",
+                                    "properties": {
+                                        "id": {
+                                            "type": "integer"
+                                        },
+                                        "page_number": {
+                                            "type": "integer"
+                                        },
+                                        "verse_mapping": {
+                                            "type": "object"
+                                        },
+                                        "first_verse_id": {
+                                            "type": "integer"
+                                        },
+                                        "last_verse_id": {
+                                            "type": "integer"
+                                        },
+                                        "verses_count": {
+                                            "type": "integer"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "examples": {
+                            "application/json": {
+                                "page": {
+                                    "id": 1,
+                                    "page_number": 507,
+                                    "verse_mapping": {
+                                        "47:1": "47:3"
+                                    },
+                                    "first_verse_id": 4787,
+                                    "last_verse_id": 4789,
+                                    "verses_count": 3
                                 }
                             }
                         }
@@ -483,13 +761,11 @@
                 {
                     "name": "page_number",
                     "in": "path",
-                    "description": "Madani Mushaf page number. Valid range is 1-604 ",
+                    "description": "Page number in the selected mushaf.",
                     "required": true,
                     "type": "integer",
                     "minimum": 1,
-                    "exclusiveMinimum": true,
-                    "maximum": 604,
-                    "exclusiveMaximum": false
+                    "exclusiveMinimum": true
                 }
             ],
             "get": {
@@ -498,7 +774,7 @@
                 "tags": [
                     "Verses"
                 ],
-                "description": "Get all verses of a specific Madani Mushaf page(1 to 604)",
+                "description": "Get all verses of a specific page in the selected mushaf.",
                 "parameters": [
                     {
                         "name": "language",
@@ -506,6 +782,12 @@
                         "description": "Language to fetch word translation in specific language.",
                         "type": "string",
                         "default": "en"
+                    },
+                    {
+                        "name": "mushaf",
+                        "in": "query",
+                        "description": "Optional mushaf id. When provided, page boundaries and line layout are resolved from the selected mushaf.",
+                        "type": "integer"
                     },
                     {
                         "name": "words",
@@ -1419,7 +1701,8 @@
                 "responses": {
                     "default": {
                         "description": "",
-                        "schema": {}
+                        "schema": {
+                        }
                     }
                 }
             }
@@ -3541,7 +3824,8 @@
                 "responses": {
                     "default": {
                         "description": "",
-                        "schema": {}
+                        "schema": {
+                        }
                     }
                 }
             }
@@ -3563,7 +3847,8 @@
                 },
                 "segments": {
                     "type": "array",
-                    "items": {}
+                    "items": {
+                    }
                 }
             },
             "example": {

--- a/oas.yaml
+++ b/oas.yaml
@@ -181,6 +181,187 @@ paths:
                 translated_name:
                   language_name: english
                   name: The Opener
+  /pages:
+    get:
+      operationId: LIST-pages
+      summary: List Pages
+      tags:
+        - Pages
+      description: Get all pages for the selected mushaf.
+      parameters:
+        - name: mushaf
+          in: query
+          description: Optional mushaf id. Defaults to the system default mushaf.
+          type: integer
+      responses:
+        '200':
+          description: ''
+          schema:
+            type: object
+            properties:
+              pages:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    id:
+                      type: integer
+                    page_number:
+                      type: integer
+                    verse_mapping:
+                      type: object
+                    first_verse_id:
+                      type: integer
+                    last_verse_id:
+                      type: integer
+                    verses_count:
+                      type: integer
+          examples:
+            application/json:
+              pages:
+                - id: 1
+                  page_number: 507
+                  verse_mapping:
+                    47:1: 47:3
+                  first_verse_id: 4787
+                  last_verse_id: 4789
+                  verses_count: 3
+  /pages/lookup:
+    get:
+      operationId: GET-pages-lookup
+      summary: Lookup Pages
+      tags:
+        - Pages
+      description: Get page boundaries for a chapter, juz, page, or verse range in the selected mushaf.
+      parameters:
+        - name: mushaf
+          in: query
+          description: Optional mushaf id. Defaults to the system default mushaf.
+          type: integer
+        - name: chapter_number
+          in: query
+          type: integer
+        - name: juz_number
+          in: query
+          type: integer
+        - name: page_number
+          in: query
+          type: integer
+        - name: manzil_number
+          in: query
+          type: integer
+        - name: rub_el_hizb_number
+          in: query
+          type: integer
+        - name: hizb_number
+          in: query
+          type: integer
+        - name: ruku_number
+          in: query
+          type: integer
+        - name: from
+          in: query
+          description: Starting verse key or verse id.
+          type: string
+        - name: to
+          in: query
+          description: Ending verse key or verse id.
+          type: string
+      responses:
+        '200':
+          description: ''
+          schema:
+            type: object
+            properties:
+              total_page:
+                type: integer
+              lookup_range:
+                type: object
+                properties:
+                  from:
+                    type: string
+                  to:
+                    type: string
+              pages:
+                type: object
+                additionalProperties:
+                  type: object
+                  properties:
+                    first_verse_key:
+                      type: string
+                    last_verse_key:
+                      type: string
+                    from:
+                      type: string
+                    to:
+                      type: string
+          examples:
+            application/json:
+              total_page: 2
+              lookup_range:
+                from: '47:1'
+                to: '47:5'
+              pages:
+                '507':
+                  first_verse_key: '47:1'
+                  last_verse_key: '47:3'
+                  from: '47:1'
+                  to: '47:3'
+                '508':
+                  first_verse_key: '47:4'
+                  last_verse_key: '47:5'
+                  from: '47:4'
+                  to: '47:5'
+  '/pages/{id}':
+    parameters:
+      - name: id
+        in: path
+        description: Page number in the selected mushaf.
+        required: true
+        type: integer
+        minimum: 1
+    get:
+      operationId: GET-pages-page_number
+      summary: Get Page
+      tags:
+        - Pages
+      description: Get metadata for a single page in the selected mushaf.
+      parameters:
+        - name: mushaf
+          in: query
+          description: Optional mushaf id. Defaults to the system default mushaf.
+          type: integer
+      responses:
+        '200':
+          description: ''
+          schema:
+            type: object
+            properties:
+              page:
+                type: object
+                properties:
+                  id:
+                    type: integer
+                  page_number:
+                    type: integer
+                  verse_mapping:
+                    type: object
+                  first_verse_id:
+                    type: integer
+                  last_verse_id:
+                    type: integer
+                  verses_count:
+                    type: integer
+          examples:
+            application/json:
+              page:
+                id: 1
+                page_number: 507
+                verse_mapping:
+                  47:1: 47:3
+                first_verse_id: 4787
+                last_verse_id: 4789
+                verses_count: 3
   '/chapters/{chapter_id}/info':
     parameters:
       - name: chapter_id
@@ -344,25 +525,27 @@ paths:
     parameters:
       - name: page_number
         in: path
-        description: 'Madani Mushaf page number. Valid range is 1-604 '
+        description: Page number in the selected mushaf.
         required: true
         type: integer
         minimum: 1
         exclusiveMinimum: true
-        maximum: 604
-        exclusiveMaximum: false
     get:
       operationId: GET_verses-by_page-page_number
       summary: By Page
       tags:
         - Verses
-      description: Get all verses of a specific Madani Mushaf page(1 to 604)
+      description: Get all verses of a specific page in the selected mushaf.
       parameters:
         - name: language
           in: query
           description: Language to fetch word translation in specific language.
           type: string
           default: en
+        - name: mushaf
+          in: query
+          description: Optional mushaf id. When provided, page boundaries and line layout are resolved from the selected mushaf.
+          type: integer
         - name: words
           in: query
           description: |-

--- a/raml10.yaml
+++ b/raml10.yaml
@@ -260,6 +260,156 @@ documentation:
           language:
             type: string
             default: en
+/pages:
+  displayName: pages
+  get:
+    displayName: LIST-pages
+    description: Get all pages for the selected mushaf.
+    responses:
+      '200':
+        body:
+          application/json: |-
+            {
+              "type": "object",
+              "properties": {
+                "pages": {
+                  "type": "array",
+                  "items": {
+                    "type": "object"
+                  }
+                }
+              },
+              "example": {
+                "pages": [
+                  {
+                    "id": 1,
+                    "page_number": 507,
+                    "verse_mapping": {
+                      "47:1": "47:3"
+                    },
+                    "first_verse_id": 4787,
+                    "last_verse_id": 4789,
+                    "verses_count": 3
+                  }
+                ]
+              }
+            }
+    queryParameters:
+      mushaf:
+        type: integer
+        description: Optional mushaf id. Defaults to the system default mushaf.
+        displayName: Optional mushaf id. Defaults to the system default mushaf.
+  /lookup:
+    displayName: lookup
+    get:
+      displayName: GET-pages-lookup
+      description: Get page boundaries for a chapter, juz, page, or verse range in the selected mushaf.
+      responses:
+        '200':
+          body:
+            application/json: |-
+              {
+                "type": "object",
+                "properties": {
+                  "total_page": {
+                    "type": "integer"
+                  },
+                  "lookup_range": {
+                    "type": "object"
+                  },
+                  "pages": {
+                    "type": "object"
+                  }
+                },
+                "example": {
+                  "total_page": 2,
+                  "lookup_range": {
+                    "from": "47:1",
+                    "to": "47:5"
+                  },
+                  "pages": {
+                    "507": {
+                      "first_verse_key": "47:1",
+                      "last_verse_key": "47:3",
+                      "from": "47:1",
+                      "to": "47:3"
+                    },
+                    "508": {
+                      "first_verse_key": "47:4",
+                      "last_verse_key": "47:5",
+                      "from": "47:4",
+                      "to": "47:5"
+                    }
+                  }
+                }
+              }
+      queryParameters:
+        mushaf:
+          type: integer
+          description: Optional mushaf id. Defaults to the system default mushaf.
+          displayName: Optional mushaf id. Defaults to the system default mushaf.
+        chapter_number:
+          type: integer
+        juz_number:
+          type: integer
+        page_number:
+          type: integer
+        manzil_number:
+          type: integer
+        rub_el_hizb_number:
+          type: integer
+        hizb_number:
+          type: integer
+        ruku_number:
+          type: integer
+        from:
+          type: string
+          description: Starting verse key or verse id.
+          displayName: Starting verse key or verse id.
+        to:
+          type: string
+          description: Ending verse key or verse id.
+          displayName: Ending verse key or verse id.
+  '/{id}':
+    displayName: id
+    uriParameters:
+      id:
+        type: integer
+        description: Page number in the selected mushaf.
+        minimum: 1
+        displayName: Page number in the selected mushaf.
+    get:
+      displayName: GET-pages-page_number
+      description: Get metadata for a single page in the selected mushaf.
+      responses:
+        '200':
+          body:
+            application/json: |-
+              {
+                "type": "object",
+                "properties": {
+                  "page": {
+                    "type": "object"
+                  }
+                },
+                "example": {
+                  "page": {
+                    "id": 1,
+                    "page_number": 507,
+                    "verse_mapping": {
+                      "47:1": "47:3"
+                    },
+                    "first_verse_id": 4787,
+                    "last_verse_id": 4789,
+                    "verses_count": 3
+                  }
+                }
+              }
+      queryParameters:
+        mushaf:
+          type: integer
+          description: Optional mushaf id. Defaults to the system default mushaf.
+          displayName: Optional mushaf id. Defaults to the system default mushaf.
 /verses:
   displayName: verses
   /by_chapter:
@@ -416,13 +566,12 @@ documentation:
       uriParameters:
         page_number:
           type: integer
-          description: 'Madani Mushaf page number. Valid range is 1-604 '
+          description: Page number in the selected mushaf.
           minimum: 1
-          maximum: 604
-          displayName: 'Madani Mushaf page number. Valid range is 1-604 '
+          displayName: Page number in the selected mushaf.
       get:
         displayName: By Page
-        description: Get all verses of a specific Madani Mushaf page(1 to 604)
+        description: Get all verses of a specific page in the selected mushaf.
         responses:
           '200':
             body:
@@ -502,6 +651,10 @@ documentation:
             default: en
             description: Language to fetch word translation in specific language.
             displayName: Language to fetch word translation in specific language.
+          mushaf:
+            type: integer
+            description: Optional mushaf id. When provided, page boundaries and line layout are resolved from the selected mushaf.
+            displayName: Optional mushaf id. When provided, page boundaries and line layout are resolved from the selected mushaf.
           words:
             type:
               - string

--- a/spec/requests/api/v4/pages_spec.rb
+++ b/spec/requests/api/v4/pages_spec.rb
@@ -1,0 +1,235 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'API::V4 Pages', type: :request do
+  before do
+    [
+      MushafPage,
+      MushafJuz,
+      Juz,
+      Verse,
+      Chapter,
+      Mushaf,
+      QiratType,
+      VerseRoot,
+      VerseLemma,
+      VerseStem
+    ].each(&:delete_all)
+
+    @qirat_type = QiratType.create!(name: 'Hafs')
+    @default_mushaf = Mushaf.create!(
+      id: 1,
+      name: 'Default Mushaf',
+      enabled: true,
+      is_default: true,
+      lines_per_page: 15,
+      pages_count: 604,
+      qirat_type: @qirat_type
+    )
+    @indopak_mushaf = Mushaf.create!(
+      id: 6,
+      name: 'Indopak Mushaf',
+      enabled: true,
+      is_default: false,
+      lines_per_page: 16,
+      pages_count: 610,
+      qirat_type: @qirat_type
+    )
+
+    @chapter = Chapter.create!(
+      chapter_number: 2,
+      name_simple: 'Test Chapter',
+      name_complex: 'Test Chapter',
+      name_arabic: 'Test Chapter',
+      revelation_place: 'madinah',
+      revelation_order: 87,
+      verses_count: 5,
+      pages: '2-3',
+      bismillah_pre: true,
+      hizbs_count: 1,
+      rub_el_hizbs_count: 1,
+      rukus_count: 1
+    )
+
+    @verse_root = VerseRoot.create!(value: 'root')
+    @verse_lemma = VerseLemma.create!(text_madani: 'lemma', text_clean: 'lemma')
+    @verse_stem = VerseStem.create!(text_madani: 'stem', text_clean: 'stem')
+
+    @verses = (1..5).map do |verse_number|
+      create_verse(
+        chapter: @chapter,
+        verse_number: verse_number,
+        page_mapping: default_page_mapping_for(verse_number),
+        juz_mapping: { 'madani' => 1, 'indopak' => 1 }
+      )
+    end
+
+    @juz = Juz.create!(
+      juz_number: 1,
+      first_verse_id: @verses.first.id,
+      last_verse_id: @verses.last.id,
+      verses_count: @verses.size,
+      verse_mapping: {}
+    )
+
+    MushafJuz.create!(
+      mushaf: @default_mushaf,
+      juz: @juz,
+      first_verse: @verses.first,
+      last_verse: @verses.last,
+      mushaf_type: :madani,
+      juz_number: 1,
+      verses_count: @verses.size,
+      verse_mapping: {}
+    )
+    MushafJuz.create!(
+      mushaf: @indopak_mushaf,
+      juz: @juz,
+      first_verse: @verses.first,
+      last_verse: @verses[3],
+      mushaf_type: :indopak,
+      juz_number: 1,
+      verses_count: 4,
+      verse_mapping: {}
+    )
+
+    create_page(@default_mushaf, 2, @verses.first, @verses[1], { '2:1' => '2:2' })
+    create_page(@default_mushaf, 3, @verses[2], @verses.last, { '2:3' => '2:5' })
+    create_page(@indopak_mushaf, 10, @verses.first, @verses[2], { '2:1' => '2:3' })
+    create_page(@indopak_mushaf, 11, @verses[3], @verses.last, { '2:4' => '2:5' })
+  end
+
+  describe 'GET /api/v4/pages' do
+    it 'returns pages for the selected mushaf' do
+      get '/api/v4/pages', params: { mushaf: @indopak_mushaf.id }
+
+      expect(response).to have_http_status(:ok)
+      expect(response_json['pages'].map { |page| page['page_number'] }).to eq([10, 11])
+      expect(response_json['pages'].first).to include(
+        'page_number' => 10,
+        'first_verse_id' => @verses.first.id,
+        'last_verse_id' => @verses[2].id,
+        'verses_count' => 3
+      )
+    end
+  end
+
+  describe 'GET /api/v4/pages/:id' do
+    it 'returns page metadata for the selected mushaf page number' do
+      get '/api/v4/pages/10', params: { mushaf: @indopak_mushaf.id }
+
+      expect(response).to have_http_status(:ok)
+      expect(response_json['page']).to include(
+        'page_number' => 10,
+        'first_verse_id' => @verses.first.id,
+        'last_verse_id' => @verses[2].id,
+        'verses_count' => 3
+      )
+    end
+  end
+
+  describe 'GET /api/v4/pages/lookup' do
+    it 'looks up pages for a chapter in the selected mushaf' do
+      get '/api/v4/pages/lookup', params: { chapter_number: @chapter.chapter_number, mushaf: @indopak_mushaf.id }
+
+      expect(response).to have_http_status(:ok)
+      expect(response_json['total_page']).to eq(2)
+      expect(response_json['lookup_range']).to eq({ 'from' => '2:1', 'to' => '2:5' })
+      expect(response_json['pages'].keys).to eq(%w[10 11])
+      expect(response_json['pages']['10']).to include(
+        'first_verse_key' => '2:1',
+        'last_verse_key' => '2:3',
+        'from' => '2:1',
+        'to' => '2:3'
+      )
+    end
+
+    it 'looks up pages for juzs using mushaf-specific juz ranges' do
+      get '/api/v4/pages/lookup', params: { juz_number: 1, mushaf: @indopak_mushaf.id }
+
+      expect(response).to have_http_status(:ok)
+      expect(response_json['lookup_range']).to eq({ 'from' => '2:1', 'to' => '2:4' })
+      expect(response_json['pages'].keys).to eq(%w[10 11])
+      expect(response_json['pages']['11']['to']).to eq('2:4')
+    end
+
+    it 'looks up a single page number in the selected mushaf' do
+      get '/api/v4/pages/lookup', params: { page_number: 10, mushaf: @indopak_mushaf.id }
+
+      expect(response).to have_http_status(:ok)
+      expect(response_json['total_page']).to eq(1)
+      expect(response_json['lookup_range']).to eq({ 'from' => '2:1', 'to' => '2:3' })
+      expect(response_json['pages']).to eq(
+        '10' => {
+          'first_verse_key' => '2:1',
+          'last_verse_key' => '2:3',
+          'from' => '2:1',
+          'to' => '2:3'
+        }
+      )
+    end
+
+    it 'looks up arbitrary verse ranges and clips page-local ranges correctly' do
+      get '/api/v4/pages/lookup', params: { from: '2:2', to: '2:4', mushaf: @indopak_mushaf.id }
+
+      expect(response).to have_http_status(:ok)
+      expect(response_json['lookup_range']).to eq({ 'from' => '2:2', 'to' => '2:4' })
+      expect(response_json['pages']).to eq(
+        '10' => {
+          'first_verse_key' => '2:1',
+          'last_verse_key' => '2:3',
+          'from' => '2:2',
+          'to' => '2:3'
+        },
+        '11' => {
+          'first_verse_key' => '2:4',
+          'last_verse_key' => '2:5',
+          'from' => '2:4',
+          'to' => '2:4'
+        }
+      )
+    end
+  end
+
+  def create_verse(chapter:, verse_number:, page_mapping:, juz_mapping:)
+    verse_key = "#{chapter.chapter_number}:#{verse_number}"
+
+    Verse.create!(
+      chapter: chapter,
+      verse_root: @verse_root,
+      verse_lemma: @verse_lemma,
+      verse_stem: @verse_stem,
+      verse_number: verse_number,
+      verse_index: QuranUtils::Quran.get_ayah_id_from_key(verse_key),
+      verse_key: verse_key,
+      juz_number: 1,
+      hizb_number: 1,
+      rub_el_hizb_number: 1,
+      manzil_number: 1,
+      ruku_number: 1,
+      page_number: page_mapping.fetch('1'),
+      v2_page: page_mapping.fetch('1'),
+      mushaf_pages_mapping: page_mapping,
+      mushaf_juzs_mapping: juz_mapping
+    )
+  end
+
+  def default_page_mapping_for(verse_number)
+    {
+      '1' => verse_number <= 2 ? 2 : 3,
+      '6' => verse_number <= 3 ? 10 : 11
+    }
+  end
+
+  def create_page(mushaf, page_number, first_verse, last_verse, verse_mapping)
+    MushafPage.create!(
+      mushaf: mushaf,
+      page_number: page_number,
+      verse_mapping: verse_mapping,
+      verses_count: (last_verse.verse_number - first_verse.verse_number) + 1,
+      first_verse_id: first_verse.id,
+      last_verse_id: last_verse.id
+    )
+  end
+end

--- a/spec/requests/api/v4/verses_by_page_spec.rb
+++ b/spec/requests/api/v4/verses_by_page_spec.rb
@@ -1,0 +1,291 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'API::V4 Verses by page', type: :request do
+  before do
+    [
+      MushafWord,
+      MushafPage,
+      WordTranslation,
+      Word,
+      Verse,
+      Chapter,
+      Mushaf,
+      QiratType,
+      Language,
+      ResourceContent,
+      Author,
+      DataSource,
+      CharType,
+      Token,
+      Topic,
+      VerseRoot,
+      VerseLemma,
+      VerseStem
+    ].each(&:delete_all)
+
+    @language = Language.create!(iso_code: 'en', name: 'English', direction: 'ltr')
+    @author = Author.create!(name: 'Spec Author')
+    @data_source = DataSource.create!(name: 'Spec Source')
+    @word_translation_resource = ResourceContent.create!(
+      approved: true,
+      permission_to_share: :granted,
+      author: @author,
+      data_source: @data_source,
+      cardinality_type: ResourceContent::CardinalityType::OneWord,
+      sub_type: ResourceContent::SubType::Translation,
+      resource_type: ResourceContent::ResourceType::Content,
+      language_id: @language.id,
+      language_name: @language.name,
+      name: 'WBW'
+    )
+
+    @qirat_type = QiratType.create!(name: 'Hafs')
+    @default_mushaf = Mushaf.create!(
+      id: 1,
+      name: 'Default Mushaf',
+      enabled: true,
+      is_default: true,
+      lines_per_page: 15,
+      pages_count: 604,
+      qirat_type: @qirat_type
+    )
+    @king_fahd_mushaf = Mushaf.create!(
+      id: 5,
+      name: 'King Fahd 1441',
+      enabled: true,
+      is_default: false,
+      lines_per_page: 15,
+      pages_count: 604,
+      qirat_type: @qirat_type
+    )
+
+    @chapter_47 = Chapter.create!(
+      chapter_number: 47,
+      name_simple: 'Muhammad',
+      name_complex: 'Muhammad',
+      name_arabic: 'Muhammad',
+      revelation_place: 'madinah',
+      revelation_order: 95,
+      verses_count: 3,
+      pages: '507-508',
+      bismillah_pre: true,
+      hizbs_count: 1,
+      rub_el_hizbs_count: 1,
+      rukus_count: 1
+    )
+    @chapter_48 = Chapter.create!(
+      chapter_number: 48,
+      name_simple: 'Fath',
+      name_complex: 'Fath',
+      name_arabic: 'Fath',
+      revelation_place: 'madinah',
+      revelation_order: 111,
+      verses_count: 1,
+      pages: '511-511',
+      bismillah_pre: true,
+      hizbs_count: 1,
+      rub_el_hizbs_count: 1,
+      rukus_count: 1
+    )
+
+    @verse_root = VerseRoot.create!(value: 'root')
+    @verse_lemma = VerseLemma.create!(text_madani: 'lemma', text_clean: 'lemma')
+    @verse_stem = VerseStem.create!(text_madani: 'stem', text_clean: 'stem')
+
+    @verse_47_1 = create_verse(@chapter_47, 1, default_page: 507, king_fahd_page: 507)
+    @verse_47_2 = create_verse(@chapter_47, 2, default_page: 507, king_fahd_page: 507)
+    @verse_47_3 = create_verse(@chapter_47, 3, default_page: 508, king_fahd_page: 507)
+    @verse_48_1 = create_verse(@chapter_48, 1, default_page: 511, king_fahd_page: 511)
+
+    create_page(@default_mushaf, 507, @verse_47_1, @verse_47_2)
+    create_page(@default_mushaf, 508, @verse_47_3, @verse_47_3)
+    create_page(@default_mushaf, 511, @verse_48_1, @verse_48_1)
+
+    create_page(@king_fahd_mushaf, 507, @verse_47_1, @verse_47_3)
+    create_page(@king_fahd_mushaf, 511, @verse_48_1, @verse_48_1)
+
+    @char_type = CharType.create!(name: 'word')
+    @token = Token.create!(text: 'token')
+    @topic = Topic.create!(name: 'topic')
+
+    verse_47_1_words = create_words_for_verse(@verse_47_1, [
+      { position: 2, text_qpc_hafs: 'GEN-LAST' },
+      { position: 1, text_qpc_hafs: 'GEN-FIRST' }
+    ])
+    verse_47_2_words = create_words_for_verse(@verse_47_2, [
+      { position: 1, text_qpc_hafs: 'GEN-V2-1' }
+    ])
+    verse_47_3_words = create_words_for_verse(@verse_47_3, [
+      { position: 1, text_qpc_hafs: 'GEN-V3-1' }
+    ])
+    verse_48_1_words = create_words_for_verse(@verse_48_1, [
+      { position: 1, text_qpc_hafs: 'GEN-V48-1' }
+    ])
+
+    create_mushaf_words(@default_mushaf, @verse_47_1, verse_47_1_words, page_number: 507, line_numbers: [2, 2], texts: ['DEF-FIRST', 'DEF-SECOND'], positions: [1, 2])
+    create_mushaf_words(@default_mushaf, @verse_47_2, verse_47_2_words, page_number: 507, line_numbers: [3], texts: ['DEF-V2-1'], positions: [1])
+    create_mushaf_words(@default_mushaf, @verse_47_3, verse_47_3_words, page_number: 508, line_numbers: [2], texts: ['DEF-V3-1'], positions: [1])
+    create_mushaf_words(@default_mushaf, @verse_48_1, verse_48_1_words, page_number: 511, line_numbers: [3], texts: ['DEF-V48-1'], positions: [1])
+
+    create_mushaf_words(@king_fahd_mushaf, @verse_47_1, verse_47_1_words, page_number: 507, line_numbers: [2, 2], texts: ['KF-FIRST', 'KF-SECOND'], positions: [1, 2])
+    create_mushaf_words(@king_fahd_mushaf, @verse_47_2, verse_47_2_words, page_number: 507, line_numbers: [3], texts: ['KF-V2-1'], positions: [1])
+    create_mushaf_words(@king_fahd_mushaf, @verse_47_3, verse_47_3_words, page_number: 507, line_numbers: [4], texts: ['KF-V3-1'], positions: [1])
+    create_mushaf_words(@king_fahd_mushaf, @verse_48_1, verse_48_1_words, page_number: 511, line_numbers: [3], texts: ['KF-V48-1'], positions: [1])
+  end
+
+  describe 'GET /api/v4/verses/by_page/:page_number' do
+    it 'uses the selected mushaf page range and mushaf words for page layout' do
+      get '/api/v4/verses/by_page/507', params: {
+        mushaf: @king_fahd_mushaf.id,
+        words: true,
+        word_fields: 'text_qpc_hafs,line_number,page_number'
+      }
+
+      expect(response).to have_http_status(:ok)
+      expect(response_json['verses'].map { |verse| verse['verse_key'] }).to eq(%w[47:1 47:2 47:3])
+
+      first_verse = response_json['verses'].first
+      expect(first_verse['page_number']).to eq(507)
+      expect(first_verse['words'].map { |word| word['text'] }).to eq(%w[KF-FIRST KF-SECOND])
+      expect(first_verse['words'].map { |word| word['page_number'] }.uniq).to eq([507])
+      expect(first_verse['words'].map { |word| word['line_number'] }.uniq).to eq([2])
+      expect(first_verse['words'].map { |word| word['text_qpc_hafs'] }).to eq(%w[GEN-LAST GEN-FIRST])
+    end
+
+    it 'changes the selected page verses when mushaf changes' do
+      get '/api/v4/verses/by_page/507', params: {
+        words: true,
+        word_fields: 'text_qpc_hafs,line_number,page_number'
+      }
+
+      expect(response).to have_http_status(:ok)
+      expect(response_json['verses'].map { |verse| verse['verse_key'] }).to eq(%w[47:1 47:2])
+      expect(response_json['verses'].first['words'].map { |word| word['text'] }).to eq(%w[DEF-FIRST DEF-SECOND])
+    end
+
+    it 'can legitimately start different pages on different physical line numbers' do
+      get '/api/v4/verses/by_page/507', params: {
+        mushaf: @king_fahd_mushaf.id,
+        words: true,
+        word_fields: 'line_number'
+      }
+      page_507_first_line = response_json['verses'].first['words'].first['line_number']
+
+      get '/api/v4/verses/by_page/511', params: {
+        mushaf: @king_fahd_mushaf.id,
+        words: true,
+        word_fields: 'line_number'
+      }
+      page_511_first_line = response_json['verses'].first['words'].first['line_number']
+
+      expect(page_507_first_line).to eq(2)
+      expect(page_511_first_line).to eq(3)
+    end
+
+    it 'keeps non-page verse endpoints on the existing generic word path' do
+      get "/api/v4/verses/by_chapter/#{@chapter_47.chapter_number}", params: {
+        words: true,
+        word_fields: 'text_qpc_hafs,line_number,page_number'
+      }
+
+      expect(response).to have_http_status(:ok)
+      first_verse = response_json['verses'].first
+      expect(first_verse['page_number']).to eq(507)
+      expect(first_verse['words'].map { |word| word['text'] }).to eq(%w[GEN-FIRST GEN-LAST])
+      expect(first_verse['words'].map { |word| word['line_number'] }.uniq).to eq([99])
+      expect(first_verse['words'].map { |word| word['page_number'] }.uniq).to eq([999])
+    end
+  end
+
+  def create_verse(chapter, verse_number, default_page:, king_fahd_page:)
+    verse_key = "#{chapter.chapter_number}:#{verse_number}"
+
+    Verse.create!(
+      chapter: chapter,
+      verse_root: @verse_root,
+      verse_lemma: @verse_lemma,
+      verse_stem: @verse_stem,
+      verse_number: verse_number,
+      verse_index: QuranUtils::Quran.get_ayah_id_from_key(verse_key),
+      verse_key: verse_key,
+      juz_number: 1,
+      hizb_number: 1,
+      rub_el_hizb_number: 1,
+      manzil_number: 1,
+      ruku_number: 1,
+      page_number: default_page,
+      v2_page: default_page,
+      mushaf_pages_mapping: {
+        @default_mushaf.id.to_s => default_page,
+        @king_fahd_mushaf.id.to_s => king_fahd_page
+      },
+      mushaf_juzs_mapping: {
+        'madani' => 1
+      }
+    )
+  end
+
+  def create_page(mushaf, page_number, first_verse, last_verse)
+    MushafPage.create!(
+      mushaf: mushaf,
+      page_number: page_number,
+      verse_mapping: {},
+      verses_count: (last_verse.id - first_verse.id) + 1,
+      first_verse_id: first_verse.id,
+      last_verse_id: last_verse.id
+    )
+  end
+
+  def create_words_for_verse(verse, definitions)
+    definitions.map do |definition|
+      word = Word.create!(
+        verse: verse,
+        chapter_id: verse.chapter_id,
+        position: definition.fetch(:position),
+        verse_key: verse.verse_key,
+        page_number: 999,
+        line_number: 99,
+        v2_page: 999,
+        code_v1: 'W',
+        code_v2: 'W2',
+        text_qpc_hafs: definition.fetch(:text_qpc_hafs),
+        text_uthmani: definition.fetch(:text_qpc_hafs),
+        char_type: @char_type,
+        char_type_name: 'word',
+        token: @token,
+        topic: @topic
+      )
+
+      WordTranslation.create!(
+        word: word,
+        language: @language,
+        resource_content: @word_translation_resource,
+        text: "translation-#{word.position}",
+        language_name: @language.name
+      )
+
+      word
+    end
+  end
+
+  def create_mushaf_words(mushaf, verse, words, page_number:, line_numbers:, texts:, positions:)
+    words.zip(line_numbers, texts, positions).each_with_index do |(word, line_number, text, position_in_verse), index|
+      MushafWord.create!(
+        mushaf: mushaf,
+        verse_id: verse.id,
+        word: word,
+        word_id: word.id,
+        page_number: page_number,
+        line_number: line_number,
+        position_in_verse: position_in_verse,
+        position_in_page: index + 1,
+        position_in_line: index + 1,
+        text: text,
+        char_type_name: 'word',
+        char_type_id: @char_type.id
+      )
+    end
+  end
+end

--- a/stoplight.json
+++ b/stoplight.json
@@ -299,6 +299,316 @@
                 }
             }
         },
+        "/pages": {
+            "get": {
+                "operationId": "LIST-pages",
+                "summary": "List Pages",
+                "tags": [
+                    "Pages"
+                ],
+                "description": "Get all pages for the selected mushaf.",
+                "parameters": [
+                    {
+                        "name": "mushaf",
+                        "in": "query",
+                        "description": "Optional mushaf id. Defaults to the system default mushaf.",
+                        "type": "integer"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "pages": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "object",
+                                        "properties": {
+                                            "id": {
+                                                "type": "integer"
+                                            },
+                                            "page_number": {
+                                                "type": "integer"
+                                            },
+                                            "verse_mapping": {
+                                                "type": "object"
+                                            },
+                                            "first_verse_id": {
+                                                "type": "integer"
+                                            },
+                                            "last_verse_id": {
+                                                "type": "integer"
+                                            },
+                                            "verses_count": {
+                                                "type": "integer"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "examples": {
+                            "application/json": {
+                                "pages": [
+                                    {
+                                        "id": 1,
+                                        "page_number": 507,
+                                        "verse_mapping": {
+                                            "47:1": "47:3"
+                                        },
+                                        "first_verse_id": 4787,
+                                        "last_verse_id": 4789,
+                                        "verses_count": 3
+                                    }
+                                ]
+                            }
+                        }
+                    }
+                },
+                "x-stoplight": {
+                    "id": "LIST-pages",
+                    "beforeScript": null,
+                    "afterScript": null,
+                    "public": true,
+                    "mock": {
+                        "enabled": false,
+                        "dynamic": false,
+                        "statusCode": 200
+                    }
+                }
+            }
+        },
+        "/pages/lookup": {
+            "get": {
+                "operationId": "GET-pages-lookup",
+                "summary": "Lookup Pages",
+                "tags": [
+                    "Pages"
+                ],
+                "description": "Get page boundaries for a chapter, juz, page, or verse range in the selected mushaf.",
+                "parameters": [
+                    {
+                        "name": "mushaf",
+                        "in": "query",
+                        "description": "Optional mushaf id. Defaults to the system default mushaf.",
+                        "type": "integer"
+                    },
+                    {
+                        "name": "chapter_number",
+                        "in": "query",
+                        "type": "integer"
+                    },
+                    {
+                        "name": "juz_number",
+                        "in": "query",
+                        "type": "integer"
+                    },
+                    {
+                        "name": "page_number",
+                        "in": "query",
+                        "type": "integer"
+                    },
+                    {
+                        "name": "manzil_number",
+                        "in": "query",
+                        "type": "integer"
+                    },
+                    {
+                        "name": "rub_el_hizb_number",
+                        "in": "query",
+                        "type": "integer"
+                    },
+                    {
+                        "name": "hizb_number",
+                        "in": "query",
+                        "type": "integer"
+                    },
+                    {
+                        "name": "ruku_number",
+                        "in": "query",
+                        "type": "integer"
+                    },
+                    {
+                        "name": "from",
+                        "in": "query",
+                        "description": "Starting verse key or verse id.",
+                        "type": "string"
+                    },
+                    {
+                        "name": "to",
+                        "in": "query",
+                        "description": "Ending verse key or verse id.",
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "total_page": {
+                                    "type": "integer"
+                                },
+                                "lookup_range": {
+                                    "type": "object",
+                                    "properties": {
+                                        "from": {
+                                            "type": "string"
+                                        },
+                                        "to": {
+                                            "type": "string"
+                                        }
+                                    }
+                                },
+                                "pages": {
+                                    "type": "object",
+                                    "additionalProperties": {
+                                        "type": "object",
+                                        "properties": {
+                                            "first_verse_key": {
+                                                "type": "string"
+                                            },
+                                            "last_verse_key": {
+                                                "type": "string"
+                                            },
+                                            "from": {
+                                                "type": "string"
+                                            },
+                                            "to": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "examples": {
+                            "application/json": {
+                                "total_page": 2,
+                                "lookup_range": {
+                                    "from": "47:1",
+                                    "to": "47:5"
+                                },
+                                "pages": {
+                                    "507": {
+                                        "first_verse_key": "47:1",
+                                        "last_verse_key": "47:3",
+                                        "from": "47:1",
+                                        "to": "47:3"
+                                    },
+                                    "508": {
+                                        "first_verse_key": "47:4",
+                                        "last_verse_key": "47:5",
+                                        "from": "47:4",
+                                        "to": "47:5"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "x-stoplight": {
+                    "id": "GET-pages-lookup",
+                    "beforeScript": null,
+                    "afterScript": null,
+                    "public": true,
+                    "mock": {
+                        "enabled": false,
+                        "dynamic": false,
+                        "statusCode": 200
+                    }
+                }
+            }
+        },
+        "/pages/{id}": {
+            "parameters": [
+                {
+                    "name": "id",
+                    "in": "path",
+                    "description": "Page number in the selected mushaf.",
+                    "required": true,
+                    "type": "integer",
+                    "minimum": 1
+                }
+            ],
+            "get": {
+                "operationId": "GET-pages-page_number",
+                "summary": "Get Page",
+                "tags": [
+                    "Pages"
+                ],
+                "description": "Get metadata for a single page in the selected mushaf.",
+                "parameters": [
+                    {
+                        "name": "mushaf",
+                        "in": "query",
+                        "description": "Optional mushaf id. Defaults to the system default mushaf.",
+                        "type": "integer"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "page": {
+                                    "type": "object",
+                                    "properties": {
+                                        "id": {
+                                            "type": "integer"
+                                        },
+                                        "page_number": {
+                                            "type": "integer"
+                                        },
+                                        "verse_mapping": {
+                                            "type": "object"
+                                        },
+                                        "first_verse_id": {
+                                            "type": "integer"
+                                        },
+                                        "last_verse_id": {
+                                            "type": "integer"
+                                        },
+                                        "verses_count": {
+                                            "type": "integer"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "examples": {
+                            "application/json": {
+                                "page": {
+                                    "id": 1,
+                                    "page_number": 507,
+                                    "verse_mapping": {
+                                        "47:1": "47:3"
+                                    },
+                                    "first_verse_id": 4787,
+                                    "last_verse_id": 4789,
+                                    "verses_count": 3
+                                }
+                            }
+                        }
+                    }
+                },
+                "x-stoplight": {
+                    "id": "GET-pages-page_number",
+                    "beforeScript": null,
+                    "afterScript": null,
+                    "public": true,
+                    "mock": {
+                        "enabled": false,
+                        "dynamic": false,
+                        "statusCode": 200
+                    }
+                }
+            }
+        },
         "/chapters/{chapter_id}/info": {
             "parameters": [
                 {
@@ -549,13 +859,11 @@
                 {
                     "name": "page_number",
                     "in": "path",
-                    "description": "Madani Mushaf page number. Valid range is 1-604 ",
+                    "description": "Page number in the selected mushaf.",
                     "required": true,
                     "type": "integer",
                     "minimum": 1,
-                    "exclusiveMinimum": true,
-                    "maximum": 604,
-                    "exclusiveMaximum": false
+                    "exclusiveMinimum": true
                 }
             ],
             "get": {
@@ -564,7 +872,7 @@
                 "tags": [
                     "Verses"
                 ],
-                "description": "Get all verses of a specific Madani Mushaf page(1 to 604)",
+                "description": "Get all verses of a specific page in the selected mushaf.",
                 "parameters": [
                     {
                         "name": "language",
@@ -572,6 +880,12 @@
                         "description": "Language to fetch word translation in specific language.",
                         "type": "string",
                         "default": "en"
+                    },
+                    {
+                        "name": "mushaf",
+                        "in": "query",
+                        "description": "Optional mushaf id. When provided, page boundaries and line layout are resolved from the selected mushaf.",
+                        "type": "integer"
                     },
                     {
                         "name": "words",
@@ -5050,6 +5364,25 @@
                         ]
                     },
                     {
+                        "name": "Pages",
+                        "description": null,
+                        "divider": false,
+                        "items": [
+                            {
+                                "_id": "LIST-pages",
+                                "type": "endpoints"
+                            },
+                            {
+                                "_id": "GET-pages-lookup",
+                                "type": "endpoints"
+                            },
+                            {
+                                "_id": "GET-pages-page_number",
+                                "type": "endpoints"
+                            }
+                        ]
+                    },
+                    {
                         "name": "Verses",
                         "description": "Get list of #model:J83wDRc48FrARPHBY\n\nYou can filter verses by `chapter`, `page`, `juz`, `rub`, and `hizb`. \n\n### Customizing the results\n\nAPI will send minimal ayah and words fields, ayah #model:XCinMTfQdCrC3D3vH, #model:D7oy5DF6aGMhfLwDB or #model:knzdXGgyjYnAqbhGX is also not included by default. You can customize the results using following query strings.\n\n- `words` words are inlcuded by default, pass any fasly value(false, f, 0) if you don't want to include ayah words\n\n- `translations` comma separated ids of translations you want to fetch for each ayah. See #endpoint:N4JAF8phDshhyrBHs endpoint to fetch list of available translations.\n\n- `tafsirs` comma seperated ids of tafsirs you want to fetch for each ayah. See #endpoint:5YnxJJGPMCLnM6PNE endpoint to fetch list of available tafsirs.\n\n- `audio` single integer value of recitaiton you want to fetch for each ayah. See #endpoint:HLbauN2sdGitPQPPL endpoint for available recitations.\n\n- `fields` comma seperated list of  #model:J83wDRc48FrARPHBY fields. Use this query string if you need to fetch more fields of each ayah.\n\n- `word_fields` api is sending `code_v1` QCF font for words. Use this query string if you need to fetch other fields of each words. e.g `word_fields=text_uthmani` will return Uthmani text of each word.\n\n- `translation_fields` if you need to fetch more fields of translations. See translation model for available fields.\n\n- `tafsir_fields` if you need to fetch more fields for tafsir.",
                         "divider": false,
@@ -5410,7 +5743,7 @@
                 "name": "Getting content in other languages",
                 "content": "API by defult send Translated names of #model:aC7ed7aoTAZEKLCGF, #model:wc8vsnXdQpa7bpWa4, #model:sPq4bZJQ5hqar4gmB translation, and names of some other resources in English. \n\n\nYou can use `language` query string in most api calls to fetch content in other langages. \n\nFor example this api call\n`/v4/chapters/1/info?language=ur` will send chapter info in Urdu language.\n\nand `/api/v4/verses/by_chapter/1?language=ur&words=true` will send word by word translation in Urdu language.\n\nFor list of available languages and their iso codes, see  #endpoint:EZsWyDnekGaDKaCpt endpoint.",
                 "public": true
-            },
+            }
         },
         "mock": {
             "enabled": false,

--- a/stoplight.yaml
+++ b/stoplight.yaml
@@ -217,6 +217,214 @@ paths:
           enabled: false
           dynamic: false
           statusCode: 200
+  /pages:
+    get:
+      operationId: LIST-pages
+      summary: List Pages
+      tags:
+        - Pages
+      description: Get all pages for the selected mushaf.
+      parameters:
+        - name: mushaf
+          in: query
+          description: Optional mushaf id. Defaults to the system default mushaf.
+          type: integer
+      responses:
+        '200':
+          description: ''
+          schema:
+            type: object
+            properties:
+              pages:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    id:
+                      type: integer
+                    page_number:
+                      type: integer
+                    verse_mapping:
+                      type: object
+                    first_verse_id:
+                      type: integer
+                    last_verse_id:
+                      type: integer
+                    verses_count:
+                      type: integer
+          examples:
+            application/json:
+              pages:
+                - id: 1
+                  page_number: 507
+                  verse_mapping:
+                    47:1: 47:3
+                  first_verse_id: 4787
+                  last_verse_id: 4789
+                  verses_count: 3
+      x-stoplight:
+        id: LIST-pages
+        beforeScript: null
+        afterScript: null
+        public: true
+        mock:
+          enabled: false
+          dynamic: false
+          statusCode: 200
+  /pages/lookup:
+    get:
+      operationId: GET-pages-lookup
+      summary: Lookup Pages
+      tags:
+        - Pages
+      description: Get page boundaries for a chapter, juz, page, or verse range in the selected mushaf.
+      parameters:
+        - name: mushaf
+          in: query
+          description: Optional mushaf id. Defaults to the system default mushaf.
+          type: integer
+        - name: chapter_number
+          in: query
+          type: integer
+        - name: juz_number
+          in: query
+          type: integer
+        - name: page_number
+          in: query
+          type: integer
+        - name: manzil_number
+          in: query
+          type: integer
+        - name: rub_el_hizb_number
+          in: query
+          type: integer
+        - name: hizb_number
+          in: query
+          type: integer
+        - name: ruku_number
+          in: query
+          type: integer
+        - name: from
+          in: query
+          description: Starting verse key or verse id.
+          type: string
+        - name: to
+          in: query
+          description: Ending verse key or verse id.
+          type: string
+      responses:
+        '200':
+          description: ''
+          schema:
+            type: object
+            properties:
+              total_page:
+                type: integer
+              lookup_range:
+                type: object
+                properties:
+                  from:
+                    type: string
+                  to:
+                    type: string
+              pages:
+                type: object
+                additionalProperties:
+                  type: object
+                  properties:
+                    first_verse_key:
+                      type: string
+                    last_verse_key:
+                      type: string
+                    from:
+                      type: string
+                    to:
+                      type: string
+          examples:
+            application/json:
+              total_page: 2
+              lookup_range:
+                from: '47:1'
+                to: '47:5'
+              pages:
+                '507':
+                  first_verse_key: '47:1'
+                  last_verse_key: '47:3'
+                  from: '47:1'
+                  to: '47:3'
+                '508':
+                  first_verse_key: '47:4'
+                  last_verse_key: '47:5'
+                  from: '47:4'
+                  to: '47:5'
+      x-stoplight:
+        id: GET-pages-lookup
+        beforeScript: null
+        afterScript: null
+        public: true
+        mock:
+          enabled: false
+          dynamic: false
+          statusCode: 200
+  '/pages/{id}':
+    parameters:
+      - name: id
+        in: path
+        description: Page number in the selected mushaf.
+        required: true
+        type: integer
+        minimum: 1
+    get:
+      operationId: GET-pages-page_number
+      summary: Get Page
+      tags:
+        - Pages
+      description: Get metadata for a single page in the selected mushaf.
+      parameters:
+        - name: mushaf
+          in: query
+          description: Optional mushaf id. Defaults to the system default mushaf.
+          type: integer
+      responses:
+        '200':
+          description: ''
+          schema:
+            type: object
+            properties:
+              page:
+                type: object
+                properties:
+                  id:
+                    type: integer
+                  page_number:
+                    type: integer
+                  verse_mapping:
+                    type: object
+                  first_verse_id:
+                    type: integer
+                  last_verse_id:
+                    type: integer
+                  verses_count:
+                    type: integer
+          examples:
+            application/json:
+              page:
+                id: 1
+                page_number: 507
+                verse_mapping:
+                  47:1: 47:3
+                first_verse_id: 4787
+                last_verse_id: 4789
+                verses_count: 3
+      x-stoplight:
+        id: GET-pages-page_number
+        beforeScript: null
+        afterScript: null
+        public: true
+        mock:
+          enabled: false
+          dynamic: false
+          statusCode: 200
   '/chapters/{chapter_id}/info':
     parameters:
       - name: chapter_id
@@ -398,25 +606,27 @@ paths:
     parameters:
       - name: page_number
         in: path
-        description: 'Madani Mushaf page number. Valid range is 1-604 '
+        description: Page number in the selected mushaf.
         required: true
         type: integer
         minimum: 1
         exclusiveMinimum: true
-        maximum: 604
-        exclusiveMaximum: false
     get:
       operationId: GET_verses-by_page-page_number
       summary: By Page
       tags:
         - Verses
-      description: Get all verses of a specific Madani Mushaf page(1 to 604)
+      description: Get all verses of a specific page in the selected mushaf.
       parameters:
         - name: language
           in: query
           description: Language to fetch word translation in specific language.
           type: string
           default: en
+        - name: mushaf
+          in: query
+          description: Optional mushaf id. When provided, page boundaries and line layout are resolved from the selected mushaf.
+          type: integer
         - name: words
           in: query
           description: |-


### PR DESCRIPTION
## Summary
This PR brings the public `v4` page APIs in line with the mushaf-aware `qdc` behavior for page layout use cases.

It does two things:
- adds the missing `v4/pages` endpoints that were already implied by our public tutorial flow
- fixes `GET /api/v4/verses/by_page/:page_number` so `mushaf` actually affects page lookup and line layout

## Why This Change
We had three concrete problems in the current `v4` surface:
- `v4/pages/lookup` was documented but not implemented
- `v4/verses/by_page/:page_number` accepted `mushaf`, but the `by_page` path still resolved against the default mushaf internally
- `v4` page word layout was still sourced from generic `words` layout data instead of mushaf-specific `mushaf_words`

That led to incorrect page/layout behavior for alternate mushafs and forced users to fall back to `qdc` for accurate print layout.

## What Changed
### 1. Add `v4/pages` parity with `qdc`
Added:
- `GET /api/v4/pages`
- `GET /api/v4/pages/lookup`
- `GET /api/v4/pages/:id`

These routes reuse the existing mushaf-aware page presenter behavior and return the same snake_case lookup/page payload shape already used by `qdc`.

### 2. Make `v4/verses/by_page` mushaf-aware
Updated the `v4` verse finder so the `by_page` flow now:
- threads the selected `mushaf` into page resolution
- resolves the page using the selected mushaf instead of the default mushaf
- sources page/line layout for `by_page` word rendering from `mushaf_words`

Non-`by_page` verse endpoints stay on the current `v4` path. This PR only changes the page-layout behavior where mushaf-specific layout is required.

### 3. Sync API contracts
Updated:
- `oas.yaml`
- `oas.json`
- `stoplight.yaml`
- `stoplight.json`
- `raml10.yaml`

The contracts now include the new `v4/pages` endpoints and document `mushaf` on `verses/by_page` without hard-coding a Madani-only `1-604` page assumption.

### 4. Add request coverage
Added request specs for:
- `GET /api/v4/pages`
- `GET /api/v4/pages/:id`
- `GET /api/v4/pages/lookup`
- `GET /api/v4/verses/by_page/:page_number` mushaf-aware behavior

## Files To Review
Core runtime changes:
- `config/routes/api/v4.rb`
- `app/controllers/api/v4/pages_controller.rb`
- `app/finders/v4/verse_finder.rb`
- `app/presenters/verses_presenter.rb`
- `app/views/api/v4/pages/*`
- `app/views/api/v4/verses/_verse.json.streamer`
- `app/views/api/v4/verses/_verses.json.streamer`
- `app/views/api/v4/verses/_word.json.streamer`
- `app/views/api/v4/verses/random.json.streamer`

Contract changes:
- `oas.yaml`
- `oas.json`
- `stoplight.yaml`
- `stoplight.json`
- `raml10.yaml`

Specs:
- `spec/requests/api/v4/pages_spec.rb`
- `spec/requests/api/v4/verses_by_page_spec.rb`

## Out Of Scope
- no `GET /api/v4/pages/layout/:page_number` route was added
- no docs repo changes are included here
- non-`by_page` `v4` verse flows are intentionally unchanged

## Verification
Verified against staging data through the API container:
- `GET /api/v4/pages/lookup?chapter_number=47&mushaf=5` returns `200`
- `GET /api/v4/pages/507?mushaf=5` returns `200`
- `GET /api/v4/verses/by_page/507?mushaf=5&words=true&word_fields=text_qpc_hafs,line_number,page_number` returns `200`
- `GET /api/v4/verses/by_page/507?mushaf=5` matches `qdc` for the first verse line layout check
- page `507` for mushaf `5` starts on line `2`
- page `511` for mushaf `5` starts on line `3`

Note: when hitting the container locally in production mode, the requests need `Host: apis.quran.foundation` because host authorization is enabled.